### PR TITLE
fix: add hourly auto-poll and trigger company detection after XML attach

### DIFF
--- a/edocument_integration/api.py
+++ b/edocument_integration/api.py
@@ -335,6 +335,10 @@ def webhook(**kwargs):
 			}
 		)
 		file_doc.save(ignore_permissions=True)
+
+		# Save EDocument again to trigger field detection (company, etc.) from attached XML
+		edocument.reload()
+		edocument.save(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep: Webhook must persist before returning
 
 		result = {"edocument": edocument.name, "document_id": document_id}

--- a/edocument_integration/api.py
+++ b/edocument_integration/api.py
@@ -360,7 +360,7 @@ def webhook(**kwargs):
 
 
 @frappe.whitelist()
-def poll_incoming_invoices(profile=None, company=None):
+def poll_incoming_invoices(profile: str | None = None, company: str | None = None):
 	"""
 	Poll Recommand inbox for incoming invoices and create EDocument records.
 

--- a/edocument_integration/hooks.py
+++ b/edocument_integration/hooks.py
@@ -145,23 +145,11 @@ doctype_js = {
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
-# 	"all": [
-# 		"edocument_integration.tasks.all"
-# 	],
-# 	"daily": [
-# 		"edocument_integration.tasks.daily"
-# 	],
-# 	"hourly": [
-# 		"edocument_integration.tasks.hourly"
-# 	],
-# 	"weekly": [
-# 		"edocument_integration.tasks.weekly"
-# 	],
-# 	"monthly": [
-# 		"edocument_integration.tasks.monthly"
-# 	],
-# }
+scheduler_events = {
+	"hourly": [
+		"edocument_integration.tasks.poll_all_incoming_documents",
+	],
+}
 
 # Testing
 # -------

--- a/edocument_integration/tasks.py
+++ b/edocument_integration/tasks.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+def poll_all_incoming_documents():
+	"""Poll incoming documents for all EDocument Integration Settings."""
+	settings_list = frappe.get_all(
+		"EDocument Integration Settings",
+		pluck="name",
+	)
+
+	for settings_name in settings_list:
+		try:
+			settings = frappe.get_doc("EDocument Integration Settings", settings_name)
+			settings.poll_incoming_documents()
+			frappe.db.commit()
+		except Exception:
+			frappe.db.rollback()
+			frappe.log_error(
+				f"Auto-poll failed for {settings_name}",
+				"EDocument Auto-Poll Error",
+			)


### PR DESCRIPTION
- Add hourly scheduler to poll all integration settings automatically
- Save EDocument after XML attachment in webhook to trigger field detection