### PR TITLE
fix: use save() instead of db.set_value for transmission status

### DIFF
--- a/edocument_integration/api.py
+++ b/edocument_integration/api.py
@@ -133,7 +133,7 @@ def get_edocument_integration_settings(profile, company=None):
 
 
 @frappe.whitelist()
-def transmit_edocument(edocument_name):
+def transmit_edocument(edocument_name: str):
 	# Transmit E-document using the configured integrator
 	try:
 		edocument_doc = frappe.get_doc("EDocument", edocument_name)

--- a/edocument_integration/api.py
+++ b/edocument_integration/api.py
@@ -190,13 +190,11 @@ def transmit_edocument(edocument_name):
 		edocument_doc.add_comment(comment_type="Info", text="\n".join(parts))
 
 		# Set status to Transmission Successful and store reference ID
-		frappe.db.set_value(
-			"EDocument",
-			edocument_name,
-			{"status": "Transmission Successful", "error": None, "reference": transmission_id},
-			update_modified=False,
-		)
-		frappe.db.commit()
+		edocument_doc.reload()
+		edocument_doc.status = "Transmission Successful"
+		edocument_doc.error = None
+		edocument_doc.reference = transmission_id
+		edocument_doc.save()
 
 		return transmission_result
 	except frappe.ValidationError:
@@ -204,13 +202,10 @@ def transmit_edocument(edocument_name):
 		raise
 	except Exception as e:
 		# Set status to Transmission Failed
-		frappe.db.set_value(
-			"EDocument",
-			edocument_name,
-			{"status": "Transmission Failed", "error": str(e)},
-			update_modified=False,
-		)
-		frappe.db.commit()
+		edocument_doc.reload()
+		edocument_doc.status = "Transmission Failed"
+		edocument_doc.error = str(e)
+		edocument_doc.save()
 
 		frappe.log_error(
 			f"E-document transmission failed for document {edocument_name}: {e!s}",


### PR DESCRIPTION
Use edocument_doc.save() instead of frappe.db.set_value() when updating transmission status so that EDocument's on_update hook runs and syncs the status back to the source document (e.g., Sales Invoice).

fixes #7 